### PR TITLE
Revert "Bump pre-commit from 3.5.0 to 3.6.0 in /{{cookiecutter.repo_name}}"

### DIFF
--- a/{{cookiecutter.repo_name}}/dev-requirements.txt
+++ b/{{cookiecutter.repo_name}}/dev-requirements.txt
@@ -5,4 +5,4 @@ flake8-debugger==4.1.2
 isort==5.13.0
 pdbpp==0.10.3
 pip-check-updates==0.23.0
-pre-commit==3.6.0
+pre-commit==3.5.0


### PR DESCRIPTION
Reverts sliverc/cookiecutter-python-script#14

Currently we still want to suppoort 3.8 so therefore removing.